### PR TITLE
Run synchronous functions directly unless marked as unsafe

### DIFF
--- a/src/expanse/console/commands/command.py
+++ b/src/expanse/console/commands/command.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 
 from typing import TYPE_CHECKING
@@ -83,7 +82,7 @@ class Command:
 
         try:
             if not self._container:
-                if asyncio.iscoroutinefunction(handle):
+                if inspect.iscoroutinefunction(handle):
                     return await handle()
 
                 if not should_run_in_threadpool(handle):

--- a/src/expanse/console/commands/command.py
+++ b/src/expanse/console/commands/command.py
@@ -16,6 +16,7 @@ from cleo.io.null_io import NullIO
 from cleo.io.outputs.output import Verbosity
 
 from expanse.support._concurrency import run_in_threadpool
+from expanse.support._concurrency import should_run_in_threadpool
 
 
 if TYPE_CHECKING:
@@ -84,6 +85,9 @@ class Command:
             if not self._container:
                 if asyncio.iscoroutinefunction(handle):
                     return await handle()
+
+                if not should_run_in_threadpool(handle):
+                    return handle()
 
                 return await run_in_threadpool(handle)
 

--- a/src/expanse/container/container.py
+++ b/src/expanse/container/container.py
@@ -1,4 +1,3 @@
-import asyncio
 import builtins
 import collections
 import inspect
@@ -189,7 +188,7 @@ class Container:
         if is_class:
             return concrete(*positional, **keywords), None
 
-        if asyncio.iscoroutinefunction(concrete):
+        if inspect.iscoroutinefunction(concrete):
             return await concrete(*positional, **keywords), None
 
         if not should_run_in_threadpool(concrete):
@@ -224,7 +223,7 @@ class Container:
             keywords,
         ) = await self._resolve_callable_dependencies(callable_, *args, **kwargs)
 
-        if asyncio.iscoroutinefunction(callable_):
+        if inspect.iscoroutinefunction(callable_):
             return await callable_(*positional, **keywords)
 
         if not should_run_in_threadpool(callable_):

--- a/src/expanse/http/responses/response.py
+++ b/src/expanse/http/responses/response.py
@@ -11,6 +11,7 @@ from expanse.http.cookie import Cookie
 from expanse.http.cookie import SameSite
 from expanse.http.response_header_bag import ResponseHeaderBag
 from expanse.support._concurrency import run_in_threadpool
+from expanse.support._concurrency import should_run_in_threadpool
 
 
 if TYPE_CHECKING:
@@ -315,5 +316,7 @@ class Response:
         for func in self._deferred:
             if asyncio.iscoroutinefunction(func):
                 await func()
+            elif not should_run_in_threadpool(func):
+                func()
             else:
                 await run_in_threadpool(func)

--- a/src/expanse/http/responses/response.py
+++ b/src/expanse/http/responses/response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import asyncio
+import inspect
 
 from typing import TYPE_CHECKING
 from typing import Self
@@ -314,7 +314,7 @@ class Response:
         Runs all deferred functions after the response has been sent.
         """
         for func in self._deferred:
-            if asyncio.iscoroutinefunction(func):
+            if inspect.iscoroutinefunction(func):
                 await func()
             elif not should_run_in_threadpool(func):
                 func()

--- a/src/expanse/routing/router.py
+++ b/src/expanse/routing/router.py
@@ -10,6 +10,7 @@ from typing import get_origin
 
 from pydantic import BaseModel
 
+from expanse.configuration.config import Config
 from expanse.container.container import Container
 from expanse.contracts.routing.route_collection import RouteCollection
 from expanse.contracts.routing.router import Router as RouterContract
@@ -25,6 +26,7 @@ from expanse.routing.pipeline import Pipeline
 from expanse.routing.route import Route
 from expanse.routing.route_group import RouteGroup
 from expanse.support._concurrency import run_in_threadpool
+from expanse.support._concurrency import should_run_in_threadpool
 from expanse.types.http.middleware import RequestHandler
 from expanse.types.routing import Endpoint
 
@@ -34,7 +36,8 @@ if TYPE_CHECKING:
 
 
 class Router(RouterContract):
-    def __init__(self) -> None:
+    def __init__(self, config: Config) -> None:
+        self._config: Config = config
         self._finder = Finder()
         self._middleware_groups: dict[str, list[type[Middleware]]] = {}
 
@@ -89,6 +92,8 @@ class Router(RouterContract):
         return route
 
     def add_route(self, route: Route) -> Route:
+        # TODO: Check if the route handler is async safe and warn if not specified
+
         self._finder.add(route)
 
         return route
@@ -193,6 +198,8 @@ class Router(RouterContract):
 
             if route.is_async:
                 raw_response = await endpoint(*positional, **keywords)
+            elif not should_run_in_threadpool(endpoint):
+                raw_response = endpoint(*positional, **keywords)
             else:
                 raw_response = await run_in_threadpool(
                     endpoint, *positional, **keywords

--- a/src/expanse/support/_concurrency.py
+++ b/src/expanse/support/_concurrency.py
@@ -10,6 +10,7 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from contextvars import Context
 from contextvars import copy_context
+from typing import Any
 from typing import ParamSpec
 from typing import TypeVar
 
@@ -32,6 +33,15 @@ def _restore_context(context: Context) -> None:
         except LookupError:
             # the context variable was first set inside `context`
             cvar.set(new_val)
+
+
+def should_run_in_threadpool(func: Callable[..., Any]) -> bool:
+    is_async_safe: bool | None = getattr(func, "is_async_safe", None)
+
+    if is_async_safe is None:
+        is_async_safe = True
+
+    return not is_async_safe
 
 
 async def run_in_threadpool(

--- a/src/expanse/support/_concurrency.py
+++ b/src/expanse/support/_concurrency.py
@@ -10,11 +10,16 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 from contextvars import Context
 from contextvars import copy_context
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ParamSpec
 from typing import TypeVar
 
 import anyio.to_thread
+
+
+if TYPE_CHECKING:
+    from expanse.configuration.config import Config
 
 
 P = ParamSpec("P")
@@ -42,6 +47,24 @@ def should_run_in_threadpool(func: Callable[..., Any]) -> bool:
         is_async_safe = True
 
     return not is_async_safe
+
+
+def warn_about_implicit_async_safe_status(
+    func: Callable[..., Any], config: Config
+) -> None:
+    if not hasattr(func, "is_async_safe") and config.get(
+        "app.warn_implicit_async_safe", True
+    ):
+        import warnings
+
+        warnings.warn(
+            f"Synchronous function {func} is not explicitly declared"
+            + " as safe to run as-is in an asynchronous context. "
+            + "Use @async_safe() or @async_safe(False)."
+            + "You can silence this warning globally by setting"
+            + "the `APP_WARN_IMPLICIT_ASYNC_SAFE` environment variable to `false`.",
+            stacklevel=3,
+        )
 
 
 async def run_in_threadpool(

--- a/src/expanse/support/helpers.py
+++ b/src/expanse/support/helpers.py
@@ -1,13 +1,12 @@
 from collections.abc import Callable
-from typing import Any
 
 
-def async_safe(safe: bool = True) -> Callable[..., Any]:
+def async_safe[**P, R](safe: bool = True) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     Decorator to mark a function as safe/unsafe to run directly in an async context.
     """
 
-    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
         setattr(func, "is_async_safe", safe)  # noqa: B010
 
         return func

--- a/src/expanse/support/helpers.py
+++ b/src/expanse/support/helpers.py
@@ -1,0 +1,15 @@
+from collections.abc import Callable
+from typing import Any
+
+
+def async_safe(safe: bool = True) -> Callable[..., Any]:
+    """
+    Decorator to mark a function as safe/unsafe to run directly in an async context.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        setattr(func, "is_async_safe", safe)  # noqa: B010
+
+        return func
+
+    return decorator

--- a/tests/http/middleware/test_encrypt_cookies.py
+++ b/tests/http/middleware/test_encrypt_cookies.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 import pytest
 
+from expanse.configuration.config import Config
 from expanse.container.container import Container
 from expanse.contracts.encryption.encryptor import Encryptor as EncryptorContract
 from expanse.contracts.routing.router import Router as RouterContract
@@ -39,7 +40,7 @@ def container(encryptor: Encryptor) -> Container:
 
 @pytest.fixture
 def router() -> RouterContract:
-    return Router()
+    return Router(Config({}))
 
 
 @pytest.fixture

--- a/tests/routing/test_router.py
+++ b/tests/routing/test_router.py
@@ -1,0 +1,60 @@
+import pytest
+
+from expanse.configuration.config import Config
+from expanse.container.container import Container
+from expanse.http.request import Request
+from expanse.routing.route import Route
+from expanse.routing.router import Router
+from expanse.support.helpers import async_safe
+
+
+async def test_router_warns_about_implicit_async_safe_status() -> None:
+    config = Config({})
+
+    def sync_endpoint() -> str:
+        return "Hello, world!"
+
+    router = Router(config)
+    request = Request.create("http://example.com/test", method="GET")
+    router.add_route(Route.get("/test", sync_endpoint))
+    with pytest.warns(
+        UserWarning,
+        match=f"Synchronous function {sync_endpoint} is not explicitly declared",
+    ):
+        await router.handle(Container(), request)
+
+
+@pytest.mark.parametrize("is_async_safe", [True, False])
+async def test_router_does_not_warn_about_implicit_async_safe_status_if_explicit_declared(
+    is_async_safe: bool, recwarn: pytest.WarningsRecorder
+) -> None:
+    config = Config({})
+
+    @async_safe(is_async_safe)
+    def sync_endpoint() -> str:
+        return "Hello, world!"
+
+    router = Router(config)
+    request = Request.create("http://example.com/test", method="GET")
+    router.add_route(Route.get("/test", sync_endpoint))
+
+    await router.handle(Container(), request)
+
+    assert recwarn.list == []
+
+
+async def test_router_does_not_warn_about_implicit_async_safe_status_if_globally_disabled(
+    recwarn: pytest.WarningsRecorder,
+) -> None:
+    config = Config({"app": {"warn_implicit_async_safe": False}})
+
+    def sync_endpoint() -> str:
+        return "Hello, world!"
+
+    router = Router(config)
+    request = Request.create("http://example.com/test", method="GET")
+    router.add_route(Route.get("/test", sync_endpoint))
+
+    await router.handle(Container(), request)
+
+    assert recwarn.list == []

--- a/tests/schematic/test_generator.py
+++ b/tests/schematic/test_generator.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from expanse.configuration.config import Config
 from expanse.core.application import Application
 from expanse.routing.router import Router
 from expanse.schematic.generator import Generator
@@ -27,7 +28,7 @@ async def test_generated_schema(unbootstrapped_app: Application, fixture: str) -
     container = unbootstrapped_app.container
     route_file = Path(__file__).parent / "fixtures" / fixture / "routes.py"
     schema_file = Path(__file__).parent / "fixtures" / fixture / "schema.json"
-    router = Router()
+    router = Router(Config({}))
     with router.group("api", prefix="/api") as group:
         group.load_file(route_file)
 


### PR DESCRIPTION
Synchronous functions (service factories, route handlers or commands) were always run in a thread regardless of whether they were blocking or not.

This PR changes the default behavior by making the assumption that they are safe, unless they are marked as unsafe via `@async_safe(False)`.

Note that to make sure that users do not mistakenly leave unsafe functions unmarked a warning is emitted (only for route handlers for now) to notify them that they are implicitly considered safe.

These warnings can be removed completely by setting the `APP_WARN_IMPLICIT_ASYNC_SAFE` environment variable to `false`.